### PR TITLE
feat(chat): Use topic slug in URLs instead of ID

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -68,7 +68,7 @@ function App() {
           {/* Public routes */}
           <Route path="/" element={<ChatPage />} />
           <Route path="/chat" element={<ChatPage />} />
-          <Route path="/chat/:topicId" element={<ChatPage />} />
+          <Route path="/chat/:slug" element={<ChatPage />} />
 
           {/* Admin routes */}
           <Route path="/admin">

--- a/frontend/src/pages/chat/components/TopicSelector.tsx
+++ b/frontend/src/pages/chat/components/TopicSelector.tsx
@@ -4,12 +4,13 @@ import { useState, useEffect } from "react";
 interface Topic {
   id: number;
   name: string;
+  slug: string;
   description: string;
 }
 
 interface TopicSelectorProps {
   selectedTopicId: number | null;
-  onSelectTopic: (topicId: number) => void;
+  onSelectTopic: (slug: string) => void;
 }
 
 export const TopicSelector = ({
@@ -59,7 +60,7 @@ export const TopicSelector = ({
       {topics.map((topic) => (
         <button
           key={topic.id}
-          onClick={() => onSelectTopic(topic.id)}
+          onClick={() => onSelectTopic(topic.slug)}
           className={`w-full text-left px-3 py-2 rounded-lg transition-colors border-2 ${
             selectedTopicId === topic.id
               ? "bg-primary-600 text-white font-semibold border-primary-600 shadow-md"

--- a/frontend/src/pages/chat/index.tsx
+++ b/frontend/src/pages/chat/index.tsx
@@ -8,7 +8,7 @@ import { useChat } from "./hooks/useChat";
 import { useToast } from "../../hooks/use-toast";
 
 export const ChatPage = () => {
-  const { topicId: topicIdParam } = useParams<{ topicId?: string }>();
+  const { slug } = useParams<{ slug?: string }>();
   const navigate = useNavigate();
   const { toast } = useToast();
   const [selectedTopicId, setSelectedTopicId] = useState<number | null>(null);
@@ -38,25 +38,35 @@ export const ChatPage = () => {
   }, []);
 
   useEffect(() => {
-    if (topicIdParam) {
-      const topicId = parseInt(topicIdParam, 10);
-      if (!isNaN(topicId)) {
-        setSelectedTopicId(topicId);
-      } else {
-        setSelectedTopicId(null);
-      }
+    if (slug) {
+      fetch(`/api/topics/slug/${slug}`)
+        .then((res) => {
+          if (!res.ok) throw new Error("Topic not found");
+          return res.json();
+        })
+        .then((topic) => {
+          setSelectedTopicId(topic.id);
+        })
+        .catch((error) => {
+          console.error("Error fetching topic by slug:", error);
+          toast({
+            title: "오류",
+            description: "토픽을 찾을 수 없습니다.",
+            variant: "destructive",
+          });
+          setSelectedTopicId(null);
+        });
     } else {
       setSelectedTopicId(null);
     }
-  }, [topicIdParam]);
+  }, [slug, toast]);
 
   useEffect(() => {
     clearMessages();
   }, [selectedTopicId, clearMessages]);
 
-  const handleTopicSelect = (topicId: number) => {
-    setSelectedTopicId(topicId);
-    navigate(`/chat/${topicId}`, { replace: true });
+  const handleTopicSelect = (slug: string) => {
+    navigate(`/chat/${slug}`, { replace: true });
   };
 
   return (


### PR DESCRIPTION
## Summary

채팅 화면 URL을 ID 기반에서 human-readable slug 기반으로 변경

## Changes

- **Routing**: `/chat/:topicId` → `/chat/:slug` (App.tsx)
- **ChatPage**: slug 파라미터로 `/api/topics/slug/{slug}` 조회 후 `selectedTopicId` 설정
- **TopicSelector**: `onSelectTopic(slug: string)` 시그니처 변경, slug 기반 navigate

## Example

Before: `/chat/123`  
After: `/chat/python-programming`

## Validation

- Backend slug API 기존 구현 활용 (`/api/topics/slug/{slug}`)
- TypeScript/ESLint 통과
- Backend 테스트 통과 (`test_topic_slug_routes.py`)

## Files

- `frontend/src/App.tsx` (routing)
- `frontend/src/pages/chat/index.tsx` (slug 처리)
- `frontend/src/pages/chat/components/TopicSelector.tsx` (interface 변경)

---

Depends on: #40  
Split from: #39 (리뷰 피드백 반영)