### PR TITLE
feat(chat): Add sidebar toggle for topic selector

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -68,7 +68,7 @@ function App() {
           {/* Public routes */}
           <Route path="/" element={<ChatPage />} />
           <Route path="/chat" element={<ChatPage />} />
-          <Route path="/chat/:topicId" element={<ChatPage />} />
+          <Route path="/chat/:slug" element={<ChatPage />} />
 
           {/* Admin routes */}
           <Route path="/admin">

--- a/frontend/src/pages/chat/components/TopicSelector.tsx
+++ b/frontend/src/pages/chat/components/TopicSelector.tsx
@@ -4,12 +4,13 @@ import { useState, useEffect } from "react";
 interface Topic {
   id: number;
   name: string;
+  slug: string;
   description: string;
 }
 
 interface TopicSelectorProps {
   selectedTopicId: number | null;
-  onSelectTopic: (topicId: number) => void;
+  onSelectTopic: (slug: string) => void;
 }
 
 export const TopicSelector = ({
@@ -59,7 +60,7 @@ export const TopicSelector = ({
       {topics.map((topic) => (
         <button
           key={topic.id}
-          onClick={() => onSelectTopic(topic.id)}
+          onClick={() => onSelectTopic(topic.slug)}
           className={`w-full text-left px-3 py-2 rounded-lg transition-colors border-2 ${
             selectedTopicId === topic.id
               ? "bg-primary-600 text-white font-semibold border-primary-600 shadow-md"

--- a/frontend/src/pages/chat/index.tsx
+++ b/frontend/src/pages/chat/index.tsx
@@ -8,7 +8,7 @@ import { useChat } from "./hooks/useChat";
 import { useToast } from "../../hooks/use-toast";
 
 export const ChatPage = () => {
-  const { topicId: topicIdParam } = useParams<{ topicId?: string }>();
+  const { slug } = useParams<{ slug?: string }>();
   const navigate = useNavigate();
   const { toast } = useToast();
   const [selectedTopicId, setSelectedTopicId] = useState<number | null>(null);
@@ -38,25 +38,35 @@ export const ChatPage = () => {
   }, []);
 
   useEffect(() => {
-    if (topicIdParam) {
-      const topicId = parseInt(topicIdParam, 10);
-      if (!isNaN(topicId)) {
-        setSelectedTopicId(topicId);
-      } else {
-        setSelectedTopicId(null);
-      }
+    if (slug) {
+      fetch(`/api/topics/slug/${slug}`)
+        .then((res) => {
+          if (!res.ok) throw new Error("Topic not found");
+          return res.json();
+        })
+        .then((topic) => {
+          setSelectedTopicId(topic.id);
+        })
+        .catch((error) => {
+          console.error("Error fetching topic by slug:", error);
+          toast({
+            title: "오류",
+            description: "토픽을 찾을 수 없습니다.",
+            variant: "destructive",
+          });
+          setSelectedTopicId(null);
+        });
     } else {
       setSelectedTopicId(null);
     }
-  }, [topicIdParam]);
+  }, [slug, toast]);
 
   useEffect(() => {
     clearMessages();
   }, [selectedTopicId, clearMessages]);
 
-  const handleTopicSelect = (topicId: number) => {
-    setSelectedTopicId(topicId);
-    navigate(`/chat/${topicId}`, { replace: true });
+  const handleTopicSelect = (slug: string) => {
+    navigate(`/chat/${slug}`, { replace: true });
   };
 
   return (

--- a/frontend/src/pages/chat/index.tsx
+++ b/frontend/src/pages/chat/index.tsx
@@ -1,17 +1,23 @@
 import { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { v4 as uuidv4 } from "uuid";
+import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { TopicSelector } from "./components/TopicSelector";
 import { MessageList } from "./components/MessageList";
 import { MessageInput } from "./components/MessageInput";
 import { useChat } from "./hooks/useChat";
 import { useToast } from "../../hooks/use-toast";
+import { Button } from "../../components/ui/button";
 
 export const ChatPage = () => {
   const { slug } = useParams<{ slug?: string }>();
   const navigate = useNavigate();
   const { toast } = useToast();
   const [selectedTopicId, setSelectedTopicId] = useState<number | null>(null);
+  const [isSidebarVisible, setIsSidebarVisible] = useState<boolean>(() => {
+    const stored = localStorage.getItem("chat_sidebar_visible");
+    return stored === null ? true : stored === "true";
+  });
   const [sessionId] = useState(() => {
     const stored = sessionStorage.getItem("chat_session_id");
     if (stored) return stored;
@@ -69,26 +75,53 @@ export const ChatPage = () => {
     navigate(`/chat/${slug}`, { replace: true });
   };
 
+  const toggleSidebar = () => {
+    setIsSidebarVisible((prev) => {
+      const newValue = !prev;
+      localStorage.setItem("chat_sidebar_visible", String(newValue));
+      return newValue;
+    });
+  };
+
   return (
     <div className="flex h-screen bg-gradient-to-br from-secondary-50 to-secondary-100">
       <div className="flex-1 flex flex-col max-w-7xl mx-auto w-full shadow-2xl bg-white">
-        <header className="border-b-2 border-primary-100 bg-gradient-to-r from-primary-600 to-primary-700 px-8 py-6 shadow-lg">
-          <h1 className="text-3xl font-bold text-white">AI 질문 답변</h1>
-          <p className="text-sm text-primary-100 mt-2">
-            토픽을 선택하고 궁금한 점을 질문하세요
-          </p>
+        <header className="border-b-2 border-primary-100 bg-gradient-to-r from-primary-600 to-primary-700 px-8 py-6 shadow-lg flex items-center justify-between">
+          <div>
+            <h1 className="text-3xl font-bold text-white">AI 질문 답변</h1>
+            <p className="text-sm text-primary-100 mt-2">
+              토픽을 선택하고 궁금한 점을 질문하세요
+            </p>
+          </div>
+          {selectedTopicId && (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={toggleSidebar}
+              className="text-white hover:bg-primary-500 transition-colors"
+              title={isSidebarVisible ? "사이드바 숨기기" : "사이드바 표시"}
+            >
+              {isSidebarVisible ? (
+                <PanelLeftClose className="h-6 w-6" />
+              ) : (
+                <PanelLeftOpen className="h-6 w-6" />
+              )}
+            </Button>
+          )}
         </header>
 
         <div className="flex-1 flex overflow-hidden">
-          <aside className="w-72 border-r-2 border-secondary-200 bg-gradient-to-b from-white to-secondary-50 p-6 shadow-inner">
-            <h2 className="text-sm font-bold text-secondary-800 mb-4 uppercase tracking-wider">
-              토픽 선택
-            </h2>
-            <TopicSelector
-              selectedTopicId={selectedTopicId}
-              onSelectTopic={handleTopicSelect}
-            />
-          </aside>
+          {(isSidebarVisible || !selectedTopicId) && (
+            <aside className="w-72 border-r-2 border-secondary-200 bg-gradient-to-b from-white to-secondary-50 p-6 shadow-inner transition-all duration-300">
+              <h2 className="text-sm font-bold text-secondary-800 mb-4 uppercase tracking-wider">
+                토픽 선택
+              </h2>
+              <TopicSelector
+                selectedTopicId={selectedTopicId}
+                onSelectTopic={handleTopicSelect}
+              />
+            </aside>
+          )}
 
           <main className="flex-1 flex flex-col bg-white">
             {messages.length === 0 && !selectedTopicId ? (

--- a/frontend/src/pages/chat/index.tsx
+++ b/frontend/src/pages/chat/index.tsx
@@ -87,35 +87,46 @@ export const ChatPage = () => {
     <div className="flex h-screen bg-gradient-to-br from-secondary-50 to-secondary-100">
       <div className="flex-1 flex flex-col max-w-7xl mx-auto w-full shadow-2xl bg-white">
         <header className="border-b-2 border-primary-100 bg-gradient-to-r from-primary-600 to-primary-700 px-8 py-6 shadow-lg flex items-center justify-between">
-          <div>
-            <h1 className="text-3xl font-bold text-white">AI 질문 답변</h1>
-            <p className="text-sm text-primary-100 mt-2">
-              토픽을 선택하고 궁금한 점을 질문하세요
-            </p>
-          </div>
-          {selectedTopicId && (
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={toggleSidebar}
-              className="text-white hover:bg-primary-500 transition-colors"
-              title={isSidebarVisible ? "사이드바 숨기기" : "사이드바 표시"}
-            >
-              {isSidebarVisible ? (
-                <PanelLeftClose className="h-6 w-6" />
-              ) : (
+          <div className="flex items-center gap-4">
+            <div>
+              <h1 className="text-3xl font-bold text-white">AI 질문 답변</h1>
+              <p className="text-sm text-primary-100 mt-2">
+                토픽을 선택하고 궁금한 점을 질문하세요
+              </p>
+            </div>
+            {selectedTopicId && !isSidebarVisible && (
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={toggleSidebar}
+                className="text-white hover:bg-primary-500 transition-colors"
+                title="사이드바 표시"
+              >
                 <PanelLeftOpen className="h-6 w-6" />
-              )}
-            </Button>
-          )}
+              </Button>
+            )}
+          </div>
         </header>
 
         <div className="flex-1 flex overflow-hidden">
           {(isSidebarVisible || !selectedTopicId) && (
             <aside className="w-72 border-r-2 border-secondary-200 bg-gradient-to-b from-white to-secondary-50 p-6 shadow-inner transition-all duration-300">
-              <h2 className="text-sm font-bold text-secondary-800 mb-4 uppercase tracking-wider">
-                토픽 선택
-              </h2>
+              <div className="flex items-center justify-between mb-4">
+                <h2 className="text-sm font-bold text-secondary-800 uppercase tracking-wider">
+                  토픽 선택
+                </h2>
+                {selectedTopicId && (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={toggleSidebar}
+                    className="text-secondary-600 hover:bg-secondary-200 transition-colors h-8 w-8"
+                    title="사이드바 숨기기"
+                  >
+                    <PanelLeftClose className="h-5 w-5" />
+                  </Button>
+                )}
+              </div>
               <TopicSelector
                 selectedTopicId={selectedTopicId}
                 onSelectTopic={handleTopicSelect}


### PR DESCRIPTION
## Summary

채팅 화면에서 토픽 선택 사이드바를 토글 숨김/표시할 수 있는 기능 추가

## Changes

- **Toggle state**: `isSidebarVisible` state 추가 및 localStorage 연동 (`chat_sidebar_visible`)
- **Toggle button**: 사이드바 헤더에 토글 버튼 추가 (토픽 선택 시만 표시)
- **Conditional rendering**: 토픽 미선택 시 사이드바 강제 표시
- **Icons**: Lucide React `PanelLeftClose`/`PanelLeftOpen` 사용
- **Animation**: CSS transition으로 부드러운 전환

## Behavior

- 토픽 미선택 시: 사이드바 항상 표시, 토글 버튼 숨김
- 토픽 선택 시: 토글 버튼 표시, 클릭으로 사이드바 숨김/표시
- 페이지 새로고침 시 토글 상태 유지 (localStorage)

## Validation

- TypeScript/ESLint 통과
- Manual validation 완료

## Files

- `frontend/src/pages/chat/index.tsx` (+81 -40 lines)

---

Depends on: #41  
Split from: #39 (리뷰 피드백 반영)